### PR TITLE
Added specifiable player start locations to level_swap_zone

### DIFF
--- a/AREA-1/area-art-gallery-hall.tscn
+++ b/AREA-1/area-art-gallery-hall.tscn
@@ -18,6 +18,8 @@ tile_set = ExtResource("1_u2s6c")
 
 [node name="toNobel" parent="." instance=ExtResource("2_sx6ca")]
 to_scene_path = "res://AREA-NOBEL/area-nobel.tscn"
+player_spawn = 0
+save_scene = false
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="toNobel"]
 position = Vector2(7, 39.5)
@@ -25,6 +27,8 @@ shape = SubResource("RectangleShape2D_bfghs")
 
 [node name="toAud" parent="." instance=ExtResource("2_sx6ca")]
 to_scene_path = "res://AREA-1/area-audlob.tscn"
+player_spawn = 0
+save_scene = false
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="toAud"]
 position = Vector2(211, 39)

--- a/AREA-NOBEL/area-nobel.tscn
+++ b/AREA-NOBEL/area-nobel.tscn
@@ -51,6 +51,7 @@ position = Vector2(88, -42)
 [node name="level_swap_zone" parent="." instance=ExtResource("9_yu6ju")]
 position = Vector2(312, -308)
 to_scene_path = "res://AREA-1/area-art-gallery-hall.tscn"
+player_spawn = -1
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="level_swap_zone"]
 position = Vector2(4, 15)
@@ -89,3 +90,9 @@ texture = ExtResource("13_pidt3")
 position = Vector2(-8370, -12800)
 scale = Vector2(10, 10)
 shape = SubResource("RectangleShape2D_pd6hs")
+
+[node name="SpawnLocations" type="Node" parent="."]
+unique_name_in_owner = true
+
+[node name="0" type="Node2D" parent="SpawnLocations"]
+position = Vector2(286, -298)

--- a/MAIN (global control)/level_swap_zone.gd
+++ b/MAIN (global control)/level_swap_zone.gd
@@ -3,6 +3,7 @@ extends Area2D
 # always add this as a direct child of the area scene
 
 @export var to_scene_path: String = "res://" # path of the level we're moving to through here
+@export var player_spawn: int = 0 # the id of the spawn location the player should go to, -1 if default
 @export var save_scene: bool = false
 
 func switch_scene() -> void: # the most wonderful few lines of code you'll ever witness
@@ -10,7 +11,23 @@ func switch_scene() -> void: # the most wonderful few lines of code you'll ever 
 		SceneSwitcher.save_scene_and_goto(load(to_scene_path).instantiate())
 		queue_free()
 	else:
-		SceneSwitcher.goto_scene(to_scene_path)
+		var scene: Node = load(to_scene_path).instantiate()
+		if player_spawn >= 0:
+			var location: Node = scene.get_node("SpawnLocations")	
+			
+			if location == null:
+				print("SpawnLocations do not exist in this scene! Set the player_spawn to -1 on level_swap_zone if that is intended.")
+				return
+	
+			location = location.get_node(str(player_spawn))
+			
+			if location == null:
+				print("Invalid spawn location!")
+				return
+			
+			scene.get_node("Player").position = location.position
+	
+		SceneSwitcher.goto_scene(scene)
 	
 
 func _on_body_entered(body):

--- a/MAIN (global control)/scene_switcher.gd
+++ b/MAIN (global control)/scene_switcher.gd
@@ -15,13 +15,10 @@ func _ready():
 func goto_scene(path):
 	_deferred_goto_scene.call_deferred(path)
 	
-func _deferred_goto_scene(path):
+func _deferred_goto_scene(scene: Node):
 	# Free the current scene, calling queue free doesn't matter here
 	current_scene.free()
-	
-	# Instantiate the new scene
-	var scene_loader = ResourceLoader.load(path)
-	current_scene = scene_loader.instantiate()
+	current_scene = scene
 	
 	# Put the new scene in the scene tree
 	get_tree().root.add_child(current_scene)

--- a/UI/start_game.gd
+++ b/UI/start_game.gd
@@ -5,4 +5,4 @@ extends Node
 var first_scene: String = "res://MAIN (global control)/main.tscn"
 
 func _on_pressed() -> void:
-	SceneSwitcher.goto_scene(first_scene)
+	SceneSwitcher.goto_scene(load(first_scene).instantiate())


### PR DESCRIPTION
Levels should a list of start locations where player can spawn, and the level_swap_zone can now set the players initial position to one of these locations on the map.